### PR TITLE
Fix build failures with Gcc 15.

### DIFF
--- a/src/DiskMemory.h
+++ b/src/DiskMemory.h
@@ -3,6 +3,7 @@
 #ifndef VERYFASTTREE_DISKMEMORY_H
 #define VERYFASTTREE_DISKMEMORY_H
 
+#include <cstdint>
 #include <fcntl.h>
 #include <memory>
 #include <sys/mman.h>

--- a/src/NeighbourJoining.h
+++ b/src/NeighbourJoining.h
@@ -6,6 +6,7 @@
 #include "TransitionMatrix.h"
 #include "HashTable.h"
 #include "Alignment.h"
+#include <cstdint>
 #include <vector>
 #include <list>
 #include <iostream>


### PR DESCRIPTION
Starting with Gcc 15, construction of veryfasttree fails.  The relevant errors look like:

	src/DiskMemory.h:17:9: error: ‘uintptr_t’ does not name a type
	   17 |         uintptr_t ptr();
	      |         ^~~~~~~~~
	src/DiskMemory.h:10:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
	    9 | #include <string>
	  +++ |+#include <cstdint>
	   10 |

Applying compiler hints resolves the issue.

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1098063